### PR TITLE
Fix for Windigo on Ubuntu/Debian variants that use new SSH version

### DIFF
--- a/chkrootkit
+++ b/chkrootkit
@@ -1139,6 +1139,8 @@ ${find} ${ROOTDIR}usr/sbin -name in.slogind`
       printn "Searching for Linux/Ebury - Operation Windigo ssh... "; fi
    if $ssh -G 2>&1 | grep -e illegal -e unknow > /dev/null; then 
       if [ "${QUIET}" != "t" ]; then echo "nothing found"; fi
+   elif $ssh -G 2>&1 | grep usage > /dev/null; then
+      if [ "${QUIET}" != "t" ]; then echo "nothing found"; fi
    else
          echo "Possible Linux/Ebury - Operation Windigo installetd" 
    fi  


### PR DESCRIPTION
On Ubuntu and Debian variants, SSH outputs the usage now when `ssh -G` is used, because that flag is not supported anymore.

This fix just inserts another else if condition that checks whether SSH prints the usage or not. If the usage is put to stdout, everything is fine and the false positive can be ignored.
