### PR TITLE
Change exit status when checking version.

### DIFF
--- a/chkrootkit
+++ b/chkrootkit
@@ -2721,7 +2721,7 @@ do
         -q)     QUIET=t;;
 
         -V)     echo >&2 "chkrootkit version ${CHKROOTKIT_VERSION}"
-                exit 1;;
+                exit 0;;
 
         -l)     echo >&2 "$0: tests: ${TOOLS} ${TROJAN}"
                 exit 1;;


### PR DESCRIPTION
Having `chkrootkit -V` exit with an error makes it very difficult to use the command in a script. Unless there is another reason for this then I think changing it should be considered.